### PR TITLE
Adds question about making numpy it's own independent project.

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -1,3 +1,10 @@
+/*
+
+Could we separate numpy, matplotlib, and others out from skulpt
+and load them through the external libraries mechanism?
+
+*/
+
 // this is stored into sys specially, rather than created by sys
 Sk.sysmodules = new Sk.builtin.dict([]);
 Sk.realsyspath = undefined;


### PR DESCRIPTION
Hello @waywaaard. This pull request is just to start a discussion and hear your thoughts. 

I'm with https://trinket.io and work with @bzwheeler who added the ability to import external modules into skulpt. At Trinket we've had several users express an interest in using numpy in their classes. We'd love to be able to offer this to them. We discovered [http://waywaaard.github.io/skulpt/](your site) and wondered if you'd be interested in creating a separate "numpy.js" (and others like matplotlib) repo? Something similar to what we did with [https://github.com/trinketapp/pygal.js](pygal.js) is what we have in mind.

We are certainly willing to help make this happen as well as contributing updates as time allowed. Thanks very much for your thoughts!
